### PR TITLE
AgentChat streaming API (#4015)

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_base_chat_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_base_chat_agent.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
-from typing import List, Sequence
+from typing import AsyncGenerator, List, Sequence
 
 from autogen_core.base import CancellationToken
 
-from ..base import ChatAgent, Response, TaskResult, TerminationCondition
+from ..base import ChatAgent, Response, TaskResult
 from ..messages import ChatMessage, InnerMessage, TextMessage
 
 
@@ -40,12 +40,22 @@ class BaseChatAgent(ChatAgent, ABC):
         """Handles incoming messages and returns a response."""
         ...
 
+    async def on_messages_stream(
+        self, messages: Sequence[ChatMessage], cancellation_token: CancellationToken
+    ) -> AsyncGenerator[InnerMessage | Response, None]:
+        """Handles incoming messages and returns a stream of messages and
+        and the final item is the response. The base implementation in :class:`BaseChatAgent`
+        simply calls :meth:`on_messages` and yields the messages in the response."""
+        response = await self.on_messages(messages, cancellation_token)
+        for inner_message in response.inner_messages or []:
+            yield inner_message
+        yield response
+
     async def run(
         self,
         task: str,
         *,
         cancellation_token: CancellationToken | None = None,
-        termination_condition: TerminationCondition | None = None,
     ) -> TaskResult:
         """Run the agent with the given task and return the result."""
         if cancellation_token is None:
@@ -57,3 +67,25 @@ class BaseChatAgent(ChatAgent, ABC):
             messages += response.inner_messages
         messages.append(response.chat_message)
         return TaskResult(messages=messages)
+
+    async def run_stream(
+        self,
+        task: str,
+        *,
+        cancellation_token: CancellationToken | None = None,
+    ) -> AsyncGenerator[InnerMessage | ChatMessage | TaskResult, None]:
+        """Run the agent with the given task and return a stream of messages
+        and the final task result as the last item in the stream."""
+        if cancellation_token is None:
+            cancellation_token = CancellationToken()
+        first_message = TextMessage(content=task, source="user")
+        yield first_message
+        messages: List[InnerMessage | ChatMessage] = [first_message]
+        async for message in self.on_messages_stream([first_message], cancellation_token):
+            if isinstance(message, Response):
+                yield message.chat_message
+                messages.append(message.chat_message)
+                yield TaskResult(messages=messages)
+            else:
+                messages.append(message)
+                yield message

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/base/_chat_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/base/_chat_agent.py
@@ -1,11 +1,10 @@
 from dataclasses import dataclass
-from typing import List, Protocol, Sequence, runtime_checkable
+from typing import AsyncGenerator, List, Protocol, Sequence, runtime_checkable
 
 from autogen_core.base import CancellationToken
 
 from ..messages import ChatMessage, InnerMessage
-from ._task import TaskResult, TaskRunner
-from ._termination import TerminationCondition
+from ._task import TaskRunner
 
 
 @dataclass(kw_only=True)
@@ -45,12 +44,9 @@ class ChatAgent(TaskRunner, Protocol):
         """Handles incoming messages and returns a response."""
         ...
 
-    async def run(
-        self,
-        task: str,
-        *,
-        cancellation_token: CancellationToken | None = None,
-        termination_condition: TerminationCondition | None = None,
-    ) -> TaskResult:
-        """Run the agent with the given task and return the result."""
+    def on_messages_stream(
+        self, messages: Sequence[ChatMessage], cancellation_token: CancellationToken
+    ) -> AsyncGenerator[InnerMessage | Response, None]:
+        """Handles incoming messages and returns a stream of inner messages and
+        and the final item is the response."""
         ...

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/base/_task.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/base/_task.py
@@ -1,10 +1,9 @@
 from dataclasses import dataclass
-from typing import Protocol, Sequence
+from typing import AsyncGenerator, Protocol, Sequence
 
 from autogen_core.base import CancellationToken
 
 from ..messages import ChatMessage, InnerMessage
-from ._termination import TerminationCondition
 
 
 @dataclass
@@ -23,7 +22,16 @@ class TaskRunner(Protocol):
         task: str,
         *,
         cancellation_token: CancellationToken | None = None,
-        termination_condition: TerminationCondition | None = None,
     ) -> TaskResult:
         """Run the task."""
+        ...
+
+    def run_stream(
+        self,
+        task: str,
+        *,
+        cancellation_token: CancellationToken | None = None,
+    ) -> AsyncGenerator[InnerMessage | ChatMessage | TaskResult, None]:
+        """Run the task and produces a stream of messages and the final result
+        as the last item in the stream."""
         ...

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/base/_team.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/base/_team.py
@@ -1,18 +1,7 @@
 from typing import Protocol
 
-from autogen_core.base import CancellationToken
-
-from ._task import TaskResult, TaskRunner
-from ._termination import TerminationCondition
+from ._task import TaskRunner
 
 
 class Team(TaskRunner, Protocol):
-    async def run(
-        self,
-        task: str,
-        *,
-        cancellation_token: CancellationToken | None = None,
-        termination_condition: TerminationCondition | None = None,
-    ) -> TaskResult:
-        """Run the team on a given task until the termination condition is met."""
-        ...
+    pass

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/messages.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/messages.py
@@ -57,14 +57,14 @@ class ToolCallMessage(BaseMessage):
     """The tool calls."""
 
 
-class ToolCallResultMessages(BaseMessage):
+class ToolCallResultMessage(BaseMessage):
     """A message signaling the results of tool calls."""
 
     content: List[FunctionExecutionResult]
     """The tool call results."""
 
 
-InnerMessage = ToolCallMessage | ToolCallResultMessages
+InnerMessage = ToolCallMessage | ToolCallResultMessage
 """Messages for intra-agent monologues."""
 
 
@@ -80,6 +80,6 @@ __all__ = [
     "HandoffMessage",
     "ResetMessage",
     "ToolCallMessage",
-    "ToolCallResultMessages",
+    "ToolCallResultMessage",
     "ChatMessage",
 ]

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_round_robin_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_round_robin_group_chat.py
@@ -61,24 +61,45 @@ class RoundRobinGroupChat(BaseGroupChat):
 
         .. code-block:: python
 
-            from autogen_agentchat.agents import ToolUseAssistantAgent
-            from autogen_agentchat.teams import RoundRobinGroupChat, StopMessageTermination
+            from autogen_ext.models import OpenAIChatCompletionClient
+            from autogen_agentchat.agents import AssistantAgent
+            from autogen_agentchat.teams import RoundRobinGroupChat
+            from autogen_agentchat.task import StopMessageTermination
 
-            assistant = ToolUseAssistantAgent("Assistant", model_client=..., registered_tools=...)
+            model_client = OpenAIChatCompletionClient(model="gpt-4o")
+
+
+            async def get_weather(location: str) -> str:
+                return f"The weather in {location} is sunny."
+
+
+            assistant = AssistantAgent(
+                "Assistant",
+                model_client=model_client,
+                tools=[get_weather],
+            )
             team = RoundRobinGroupChat([assistant])
-            await team.run("What's the weather in New York?", termination_condition=StopMessageTermination())
+            stream = team.run_stream("What's the weather in New York?", termination_condition=StopMessageTermination())
+            async for message in stream:
+                print(message)
 
     A team with multiple participants:
 
         .. code-block:: python
 
-            from autogen_agentchat.agents import CodingAssistantAgent, CodeExecutorAgent
-            from autogen_agentchat.teams import RoundRobinGroupChat, StopMessageTermination
+            from autogen_ext.models import OpenAIChatCompletionClient
+            from autogen_agentchat.agents import AssistantAgent
+            from autogen_agentchat.teams import RoundRobinGroupChat
+            from autogen_agentchat.task import StopMessageTermination
 
-            coding_assistant = CodingAssistantAgent("Coding_Assistant", model_client=...)
-            executor_agent = CodeExecutorAgent("Code_Executor", code_executor=...)
-            team = RoundRobinGroupChat([coding_assistant, executor_agent])
-            await team.run("Write a program that prints 'Hello, world!'", termination_condition=StopMessageTermination())
+            model_client = OpenAIChatCompletionClient(model="gpt-4o")
+
+            agent1 = AssistantAgent("Assistant1", model_client=model_client)
+            agent2 = AssistantAgent("Assistant2", model_client=model_client)
+            team = RoundRobinGroupChat([agent1, agent2])
+            stream = team.run_stream("Tell me some jokes.", termination_condition=StopMessageTermination())
+            async for message in stream:
+                print(message)
 
     """
 

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_swarm_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_swarm_group_chat.py
@@ -79,7 +79,10 @@ class Swarm(BaseGroupChat):
             )
 
             team = Swarm([agent1, agent2])
-            await team.run("What is bob's birthday?", termination_condition=MaxMessageTermination(3))
+
+            stream = team.run_stream("What is bob's birthday?", termination_condition=MaxMessageTermination(3))
+            async for message in stream:
+                print(message)
     """
 
     def __init__(self, participants: List[ChatAgent], termination_condition: TerminationCondition | None = None):

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -12,7 +12,7 @@ from autogen_agentchat.agents import (
     CodeExecutorAgent,
     Handoff,
 )
-from autogen_agentchat.base import Response
+from autogen_agentchat.base import Response, TaskResult
 from autogen_agentchat.logging import FileLogHandler
 from autogen_agentchat.messages import (
     ChatMessage,
@@ -20,7 +20,7 @@ from autogen_agentchat.messages import (
     StopMessage,
     TextMessage,
     ToolCallMessage,
-    ToolCallResultMessages,
+    ToolCallResultMessage,
 )
 from autogen_agentchat.task import MaxMessageTermination, StopMessageTermination
 from autogen_agentchat.teams import (
@@ -58,6 +58,9 @@ class _MockChatCompletion:
         completion = self._saved_chat_completions[self._curr_index]
         self._curr_index += 1
         return completion
+
+    def reset(self) -> None:
+        self._curr_index = 0
 
 
 class _EchoAgent(BaseChatAgent):
@@ -147,7 +150,8 @@ async def test_round_robin_group_chat(monkeypatch: pytest.MonkeyPatch) -> None:
         )
         team = RoundRobinGroupChat(participants=[coding_assistant_agent, code_executor_agent])
         result = await team.run(
-            "Write a program that prints 'Hello, world!'", termination_condition=StopMessageTermination()
+            "Write a program that prints 'Hello, world!'",
+            termination_condition=StopMessageTermination(),
         )
         expected_messages = [
             "Write a program that prints 'Hello, world!'",
@@ -163,6 +167,18 @@ async def test_round_robin_group_chat(monkeypatch: pytest.MonkeyPatch) -> None:
 
         # Assert that all expected messages are in the collected messages
         assert normalized_messages == expected_messages
+
+        # Test streaming.
+        mock.reset()
+        index = 0
+        async for message in team.run_stream(
+            "Write a program that prints 'Hello, world!'", termination_condition=StopMessageTermination()
+        ):
+            if isinstance(message, TaskResult):
+                assert message == result
+            else:
+                assert message == result.messages[index]
+            index += 1
 
 
 @pytest.mark.asyncio
@@ -230,13 +246,14 @@ async def test_round_robin_group_chat_with_tools(monkeypatch: pytest.MonkeyPatch
     echo_agent = _EchoAgent("echo_agent", description="echo agent")
     team = RoundRobinGroupChat(participants=[tool_use_agent, echo_agent])
     result = await team.run(
-        "Write a program that prints 'Hello, world!'", termination_condition=StopMessageTermination()
+        "Write a program that prints 'Hello, world!'",
+        termination_condition=StopMessageTermination(),
     )
 
     assert len(result.messages) == 6
     assert isinstance(result.messages[0], TextMessage)  # task
     assert isinstance(result.messages[1], ToolCallMessage)  # tool call
-    assert isinstance(result.messages[2], ToolCallResultMessages)  # tool call result
+    assert isinstance(result.messages[2], ToolCallResultMessage)  # tool call result
     assert isinstance(result.messages[3], TextMessage)  # tool use agent response
     assert isinstance(result.messages[4], TextMessage)  # echo agent response
     assert isinstance(result.messages[5], StopMessage)  # tool use agent response
@@ -252,6 +269,19 @@ async def test_round_robin_group_chat_with_tools(monkeypatch: pytest.MonkeyPatch
     assert context[2].content[0].content == "pass"
     assert context[2].content[0].call_id == "1"
     assert context[3].content == "Hello"
+
+    # Test streaming.
+    tool_use_agent._model_context.clear()  # pyright: ignore
+    mock.reset()
+    index = 0
+    async for message in team.run_stream(
+        "Write a program that prints 'Hello, world!'", termination_condition=StopMessageTermination()
+    ):
+        if isinstance(message, TaskResult):
+            assert message == result
+        else:
+            assert message == result.messages[index]
+        index += 1
 
 
 @pytest.mark.asyncio
@@ -320,7 +350,8 @@ async def test_selector_group_chat(monkeypatch: pytest.MonkeyPatch) -> None:
         model_client=OpenAIChatCompletionClient(model=model, api_key=""),
     )
     result = await team.run(
-        "Write a program that prints 'Hello, world!'", termination_condition=StopMessageTermination()
+        "Write a program that prints 'Hello, world!'",
+        termination_condition=StopMessageTermination(),
     )
     assert len(result.messages) == 6
     assert result.messages[0].content == "Write a program that prints 'Hello, world!'"
@@ -329,6 +360,19 @@ async def test_selector_group_chat(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result.messages[3].source == "agent1"
     assert result.messages[4].source == "agent2"
     assert result.messages[5].source == "agent1"
+
+    # Test streaming.
+    mock.reset()
+    agent1._count = 0  # pyright: ignore
+    index = 0
+    async for message in team.run_stream(
+        "Write a program that prints 'Hello, world!'", termination_condition=StopMessageTermination()
+    ):
+        if isinstance(message, TaskResult):
+            assert message == result
+        else:
+            assert message == result.messages[index]
+        index += 1
 
 
 @pytest.mark.asyncio
@@ -356,7 +400,8 @@ async def test_selector_group_chat_two_speakers(monkeypatch: pytest.MonkeyPatch)
         model_client=OpenAIChatCompletionClient(model=model, api_key=""),
     )
     result = await team.run(
-        "Write a program that prints 'Hello, world!'", termination_condition=StopMessageTermination()
+        "Write a program that prints 'Hello, world!'",
+        termination_condition=StopMessageTermination(),
     )
     assert len(result.messages) == 5
     assert result.messages[0].content == "Write a program that prints 'Hello, world!'"
@@ -366,6 +411,19 @@ async def test_selector_group_chat_two_speakers(monkeypatch: pytest.MonkeyPatch)
     assert result.messages[4].source == "agent1"
     # only one chat completion was called
     assert mock._curr_index == 1  # pyright: ignore
+
+    # Test streaming.
+    mock.reset()
+    agent1._count = 0  # pyright: ignore
+    index = 0
+    async for message in team.run_stream(
+        "Write a program that prints 'Hello, world!'", termination_condition=StopMessageTermination()
+    ):
+        if isinstance(message, TaskResult):
+            assert message == result
+        else:
+            assert message == result.messages[index]
+        index += 1
 
 
 @pytest.mark.asyncio
@@ -422,6 +480,18 @@ async def test_selector_group_chat_two_speakers_allow_repeated(monkeypatch: pyte
     assert result.messages[2].source == "agent2"
     assert result.messages[3].source == "agent1"
 
+    # Test streaming.
+    mock.reset()
+    index = 0
+    async for message in team.run_stream(
+        "Write a program that prints 'Hello, world!'", termination_condition=StopMessageTermination()
+    ):
+        if isinstance(message, TaskResult):
+            assert message == result
+        else:
+            assert message == result.messages[index]
+        index += 1
+
 
 class _HandOffAgent(BaseChatAgent):
     def __init__(self, name: str, description: str, next_agent: str) -> None:
@@ -446,8 +516,8 @@ async def test_swarm_handoff() -> None:
     second_agent = _HandOffAgent("second_agent", description="second agent", next_agent="third_agent")
     third_agent = _HandOffAgent("third_agent", description="third agent", next_agent="first_agent")
 
-    team = Swarm([second_agent, first_agent, third_agent])
-    result = await team.run("task", termination_condition=MaxMessageTermination(6))
+    team = Swarm([second_agent, first_agent, third_agent], termination_condition=MaxMessageTermination(6))
+    result = await team.run("task")
     assert len(result.messages) == 6
     assert result.messages[0].content == "task"
     assert result.messages[1].content == "Transferred to third_agent."
@@ -455,6 +525,16 @@ async def test_swarm_handoff() -> None:
     assert result.messages[3].content == "Transferred to second_agent."
     assert result.messages[4].content == "Transferred to third_agent."
     assert result.messages[5].content == "Transferred to first_agent."
+
+    # Test streaming.
+    index = 0
+    stream = team.run_stream("task", termination_condition=MaxMessageTermination(6))
+    async for message in stream:
+        if isinstance(message, TaskResult):
+            assert message == result
+        else:
+            assert message == result.messages[index]
+        index += 1
 
 
 @pytest.mark.asyncio
@@ -514,19 +594,31 @@ async def test_swarm_handoff_using_tool_calls(monkeypatch: pytest.MonkeyPatch) -
     mock = _MockChatCompletion(chat_completions)
     monkeypatch.setattr(AsyncCompletions, "create", mock.mock_create)
 
-    agnet1 = AssistantAgent(
+    agent1 = AssistantAgent(
         "agent1",
         model_client=OpenAIChatCompletionClient(model=model, api_key=""),
         handoffs=[Handoff(target="agent2", name="handoff_to_agent2", message="handoff to agent2")],
     )
     agent2 = _HandOffAgent("agent2", description="agent 2", next_agent="agent1")
-    team = Swarm([agnet1, agent2])
+    team = Swarm([agent1, agent2])
     result = await team.run("task", termination_condition=StopMessageTermination())
     assert len(result.messages) == 7
     assert result.messages[0].content == "task"
     assert isinstance(result.messages[1], ToolCallMessage)
-    assert isinstance(result.messages[2], ToolCallResultMessages)
+    assert isinstance(result.messages[2], ToolCallResultMessage)
     assert result.messages[3].content == "handoff to agent2"
     assert result.messages[4].content == "Transferred to agent1."
     assert result.messages[5].content == "Hello"
     assert result.messages[6].content == "TERMINATE"
+
+    # Test streaming.
+    agent1._model_context.clear()  # pyright: ignore
+    mock.reset()
+    index = 0
+    stream = team.run_stream("task", termination_condition=StopMessageTermination())
+    async for message in stream:
+        if isinstance(message, TaskResult):
+            assert message == result
+        else:
+            assert message == result.messages[index]
+        index += 1


### PR DESCRIPTION
Resolves https://github.com/microsoft/autogen/issues/3969

Would be a simple way to integrate with UIs to show progress while executing a task, without getting into logging. 

from autogen_ext.models import OpenAIChatCompletionClient
from autogen_agentchat.agents import AssistantAgent
from autogen_agentchat.teams import Swarm
from autogen_agentchat.task import MaxMessageTermination

model_client = OpenAIChatCompletionClient(model="gpt-4o")

agent1 = AssistantAgent(
    "Alice",
    model_client=model_client,
    handoffs=["Bob"],
    system_message="You are Alice and you only answer questions about yourself.",
)
agent2 = AssistantAgent(
    "Bob", model_client=model_client, system_message="You are Bob and your birthday is on 1st January."
)

team = Swarm([agent1, agent2])

stream = team.run_stream("What is bob's birthday?", termination_condition=MaxMessageTermination(3))
async for message in stream:
    print(message)
source='user' content="What is bob's birthday?"
source='Alice' content=[FunctionCall(id='call_OMp2KGOi0HJNoJ1CP4sARKNq', arguments='{}', name='transfer_to_bob')]
source='Alice' content=[FunctionExecutionResult(content='Transferred to Bob, adopting the role of Bob immediately.', call_id='call_OMp2KGOi0HJNoJ1CP4sARKNq')]
source='Alice' target='Bob' content='Transferred to Bob, adopting the role of Bob immediately.'
source='Bob' content='My birthday is on 1st January.'
TaskResult(messages=[TextMessage(source='user', content="What is bob's birthday?"), ToolCallMessage(source='Alice', content=[FunctionCall(id='call_OMp2KGOi0HJNoJ1CP4sARKNq', arguments='{}', name='transfer_to_bob')]), ToolCallResultMessage(source='Alice', content=[FunctionExecutionResult(content='Transferred to Bob, adopting the role of Bob immediately.', call_id='call_OMp2KGOi0HJNoJ1CP4sARKNq')]), HandoffMessage(source='Alice', target='Bob', content='Transferred to Bob, adopting the role of Bob immediately.'), TextMessage(source='Bob', content='My birthday is on 1st January.')])